### PR TITLE
Optimized C code by moving a variable outside of a loop.

### DIFF
--- a/mtuq/misfit/waveform/c_ext_L2.c
+++ b/mtuq/misfit/waveform/c_ext_L2.c
@@ -209,8 +209,9 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
 
           // Sum cross-correlations of all components being considered
           for (ig=0; ig<NG; ig++) {
+            double source_val = sources (isrc, ig);
             for (it=0; it<NPAD; it++) {
-                cc(it) += greens_data(ista,ic,ig,it) * sources(isrc,ig);
+                cc(it) += greens_data(ista,ic,ig,it) * source_val;
             }
           }
         }


### PR DESCRIPTION
It seems that the repeated access to `sources(isrc,ig)` causes a slow-down that can be easily avoided by caching the source as:

```python3
double source_val = sources (isrc, ig)
```
in which gives the following:

```c
// Sum cross-correlations of all components being considered
for (ig=0; ig<NG; ig++) {
  double source_val = sources (isrc, ig);
  for (it=0; it<NPAD; it++) {
      cc(it) += greens_data(ista,ic,ig,it) * source_val;
  }
}
```
since `sources (isrc, ig)` only changes with the outer part of the loop. 

From local tests on my personal M1 Mac, this change yields a speedup of about ~x1.18.

Given that this modifies a key component of the code, I'd like @rmodrak to look at it before we proceed. 

🛠 **Note**:  No tentative merge date -- will be merged only upon review.