### PR TITLE
Enhances force plot and improves ForceGridRegular grid dimensioning

### DIFF
--- a/mtuq/graphics/uq/_matplotlib.py
+++ b/mtuq/graphics/uq/_matplotlib.py
@@ -263,7 +263,10 @@ def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='
         cbmin, cbmax = im.get_clim()
         ticks = np.linspace(cbmin, cbmax, 3)
         cb = pyplot.colorbar(im, ticks=ticks, location='bottom', ax=ax, pad=0.001, fraction=0.02)
-        cb.set_label('l2-misfit')
+        if 'colorbar_label' in kwargs:
+            cb.set_label(kwargs['colorbar_label'])
+        else:
+            cb.set_label('l2-misfit')
     elif plot_type == 'scatter':
         cb = pyplot.colorbar(im, location='bottom', ax=ax, pad=0.001, fraction=0.02, ticks=boundaries, extend='max')
         cb.set_label('Mismatching polarities')

--- a/mtuq/grid/force.py
+++ b/mtuq/grid/force.py
@@ -24,7 +24,7 @@ def ForceGridRegular(magnitudes_in_N=1., npts_per_axis=80):
     `len(magnitudes_in_N)*npts_per_axis^2`.
 
     """
-    phi = regular(0., 360., npts_per_axis)
+    phi = regular(0., 360., 2 * npts_per_axis)
     h = regular(-1., 1., npts_per_axis)
     F0 = asarray(magnitudes_in_N)
 


### PR DESCRIPTION
This fixes issue #301 pointed out by @ammcpherson , and also takes the oportunity to fix an unwanted behavior of the grid dimensions for `ForceGridRegular`. 

The grid coordinates on the unit sphere were previously defined as:

```python3
phi = regular(0., 360., npts_per_axis)
h = regular(-1., 1., npts_per_axis)
```

which tends to make the grid cells elongated along the h axis. By doubling the number of grid points on the phi axis, we should get squarer grid cells (~ideally we would have 1x1 aspect ratio for each grid cell, but it is not really possible on the sphere).

notes: 
- This does not impact uniformity of the grid, it is just for the sake of consistency with the way the Lune coordinates are defined.
- From my test, it does not impact the plotting functions.

Will be merged by the end of the week.