### PR TITLE
Improvements polarity modules

### DIFF
--- a/examples/Waveforms+Polarities.py
+++ b/examples/Waveforms+Polarities.py
@@ -10,7 +10,7 @@ from mtuq.grid import FullMomentTensorGridSemiregular
 from mtuq.grid_search import grid_search
 from mtuq.misfit import WaveformMisfit, PolarityMisfit
 from mtuq.process_data import ProcessData
-from mtuq.util import fullpath, merge_dicts, save_json
+from mtuq.util import fullpath, merge_dicts, save_json, sort_polarities
 from mtuq.util.cap import parse_station_codes, Trapezoid
 
 
@@ -79,17 +79,6 @@ if __name__=='__main__':
 
     polarity_misfit = PolarityMisfit(
         taup_model=model)
-
-
-    #
-    # Observed polarities can be attached to the data or passed through a 
-    # user-supplied dictionary or list in which +1 corresopnds to positive 
-    # first motion, -1 to negative first moation, and 0 to indeterminate or
-    # unpicked
-    #
-
-    polarities = np.array([-1, -1, -1, 1, 1, 0, 1, 1, -1, 1, 1, 1, 0, 1, 1, 1, -1, 1, 1, 0])
-
 
 
     #
@@ -197,6 +186,44 @@ if __name__=='__main__':
     if comm.rank==0:
         print('Evaluating polarity misfit...\n')
 
+    #
+    # Observed polarities can be attached to the data or passed through a 
+    # user-supplied dictionary or list in which +1 corresopnds to positive 
+    # first motion, -1 to negative first moation, and 0 to indeterminate or
+    # unpicked
+    #
+    
+    #First, a zeroes polarity numpy array is created with the same length of the stations in data.
+    number_stations = len(data)
+    polarities= np.zeros(number_stations)
+    #Second, the polarities dictionary is defined.
+    dict_polarity = {
+    "BMR": 0,
+    "DIV": 1,
+    "EYAK": 1,
+    "PAX": 1,
+    "SWD": 1,
+    "TRF": -1,
+    "PMR": -1,
+    "AVAL": 1,
+    "BIGB": -1,
+    "BLAK": 1,
+    "DEVL": 1,
+    "HEAD": 1,
+    "KASH": -1,
+    "LSKI": -1,
+    "LSUM": 1,
+    "MPEN": 0,
+    "NSKI": 1,
+    "PERI": 1,
+    "SOLD": 0,
+    "TUPA": 1,
+    }
+    #Third: the polarities array is populated with the polarities in the dictionary
+    #the subroutine sort_polarities helps to ensure that the order of the entered polarities
+    #is the same than the order of stations in data.
+    polarities = sort_polarities(dict_polarity,data,polarities)
+
     results_polarity = grid_search(
         polarities, greens_bw, polarity_misfit, origin, grid)
 
@@ -244,4 +271,3 @@ if __name__=='__main__':
             polarities, predicted, attrs, origin, best_mt)
 
         print('\nFinished\n')
-

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -275,19 +275,12 @@ def _takeoff_angle_taup(taup, depth_in_km, distance_in_deg):
 
     arrivals = taup.get_travel_times(
         depth_in_km, distance_in_deg, phase_list=['p', 'P'])
-
-    phases = []
-    for arrival in arrivals:
-        phases += [arrival.phase.name]
-
-    if 'p' in phases:
-        return arrivals[phases.index('p')].takeoff_angle
-
-    elif 'P' in phases:
-        return arrivals[phases.index('P')].takeoff_angle
-
-    else:
+    
+    if len(arrivals) == 0:
         raise Exception
+    else:
+        sorted_arrivals = sorted(arrivals, key=lambda arrival: arrival.time)
+        return sorted_arrivals[0].takeoff_angle
 
 
 def _polarities_mt(mt_array, takeoff, azimuth):

--- a/mtuq/util/__init__.py
+++ b/mtuq/util/__init__.py
@@ -366,6 +366,27 @@ def dataarray_idxmax(da, warnings=True):
             da = da[0]
     return da.coords
 
+def sort_polarities(dict_polarity, data, polarities):
+    """
+    Assigns polarity values from dict_polarity to polarities array based on station names in data (Obspy streams).
+
+    Args:
+        dict_polarity (dict): Dictionary mapping station names to polarity values.
+        data (list): List of Obspy streams.
+        polarities (numpy.ndarray): NumPy array to store polarity values.
+
+    Returns:
+        numpy.ndarray: Updated polarities array.
+    """
+
+    for i, stream in enumerate(data):
+        station_name = stream[0].stats.station
+        if station_name in dict_polarity:
+            polarities[i] = dict_polarity[station_name]
+        else:
+            print('Station {} not found in the dictionary'.format(station_name))
+
+    return polarities
 
 def defaults(kwargs, defaults):
     for key in defaults:


### PR DESCRIPTION
Hello, 

We are proposing two modifications. 

**1. Correction miscalculation piercing points and predicted polarities**

In the current [polarity code of MTUQ](https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmtuqorg%2Fmtuq%2Fblob%2F0a09059cfb2dbf91a4ab9b41ff8b820b786e9d78%2Fmtuq%2Fmisfit%2Fpolarity.py%23L274&data=05%7C02%7Cfelixr1%40usf.edu%7C1ae9c765eaee4ad857ae08dd6e63d589%7C741bf7dee2e546df8d6782607df9deaa%7C0%7C0%7C638788097308559814%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=MmQ1UBQbb7b8Zng9BKnFGzKMMv601efWU7JuojZAlY0%3D&reserved=0), the piercing point and the predicted polarity are based on the 'p' wave arrival when present. The 'P' wave is only used when 'p' is not observed. This led to an incorrect determination of the piercing point for stations where both 'p' and 'P' phases are observed, but the first wave arrival is 'P'. This happens because MTUQ assumes that when both phases are observed, the 'p' phase always arrives first.

In the figure, there is a synthetic example where stations at 3 different distances are deployed in a circular array. The distances are: 20km, 200km, and 300km. For a source at 6km depth, the P-wave arrivals according to the AK135 model are as follows: 

- 20km: only 'p' wave.

- 200km: 'p' and 'P' wave, with the 'P' wave arriving first.

- 300km: only 'P' wave.

<img width="2475" alt="Polarity_bug" src="https://github.com/user-attachments/assets/ce237a06-4f5e-4345-b13f-842f0ce5d0f4" />


The curves show the travel times and the take-off angles for one or both phases, if present.  For this specific source depth, in the distances between approximately 140km and 270km, the 'P' wave arrives earlier than the 'p' one. In addition, for this example, where the source orientation is a pure dip-slip source, there is also a miscalculation of the predicted polarities in the same distance interval. This is because for this specific source, the upper and lower hemisphere quadrants of the focal sphere are opposed, and hence, the 'p' polarity (upward) predicted is opposed to the 'P' first arrival (downward). 

In general, both the piercing points and the polarities are miscalculated when the 'P' phase arrives before the 'p' one. That is why in the synthetic example, the polarities show a mismatch at a distance of 200km. Because while we are observing a 'P' wave, MTUQ is calculating the take-off angle and the predicted polarity for a 'p' phase that arrives after the 'P' one. 

Once we corrected the code for making MTUQ to take the first arrival, whether 'p' or 'P', you can see that the piercing points for the 200km distance stations change while the others remain the same as expected. In addition, for the corrected case, there are no polarity mismatches. 

**2. Function sort_polarities in mtuq.util**

The example, [examples/Waveforms+Polarities.py](https://github.com/mtuqorg/mtuq/blob/master/examples/Waveforms%2BPolarities.py#L85) indicates that the user must supply a dictionary with the first P-wave arrival polarities. However, the example shows an array where the polarities are assigned in the same order as the stations listed in the [data object](https://github.com/mtuqorg/mtuq/blob/master/examples/Waveforms%2BPolarities.py#L147). We propose a modification where a dictionary with the station's name and the polarity is given, without following any specific order. Then a polarities array filled with zeroes is created and finally, by using the subroutine sort_polarities the polarities array is populated with the values in the dictionary, guaranteeing that the order of the polarities is the same as the stations ordered in data. 

This analysis was made jointly with @jbraunmiller, thanks for your attention. 



