### PR TITLE
Add taup_model as an as an optional parameter (not kewyword) to plot_beachball and plot_polarities

### DIFF
--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -32,7 +32,7 @@ from mtuq.util.beachball import convert_sphere_points_to_angles, lambert_azimuth
 import warnings
 
 
-def plot_beachball(filename, mt, stations, origin, backend=None, **kwargs):
+def plot_beachball(filename, mt, stations, origin, taup_model='ak135', backend=None, **kwargs):
     """ Plots focal mechanism and station locations
 
     .. rubric :: Required arguments
@@ -66,7 +66,7 @@ def plot_beachball(filename, mt, stations, origin, backend=None, **kwargs):
 
     ``taup_model`` (`str`):
     Name of built-in ObsPy TauP model or path to custom ObsPy TauP model,
-    used for takeoff angle calculations
+    used for takeoff angle calculations. ak135 model used by default. 
 
     """
 
@@ -75,13 +75,13 @@ def plot_beachball(filename, mt, stations, origin, backend=None, **kwargs):
 
     if backend is None:
         backend = _plot_beachball_matplotlib
-        backend(filename, mt, stations, origin, **kwargs)
+        backend(filename, mt,taup_model, stations, origin, **kwargs)
         return
     elif backend == _plot_beachball_pygmt and exists_pygmt():
-        backend(filename, mt, stations, origin, **kwargs)
+        backend(filename, mt, stations, origin, taup_model, **kwargs)
         return
     elif backend == _plot_beachball_gmt and exists_gmt() and gmt_major_version() >= 6:
-        backend(filename, mt, stations, origin, **kwargs)
+        backend(filename, mt, stations, origin, taup_model, **kwargs)
         return
 
     try:
@@ -95,7 +95,7 @@ def plot_beachball(filename, mt, stations, origin, backend=None, **kwargs):
         warn("plot_beachball: Plotting failed")
 
 
-def plot_polarities(filename, observed, predicted, stations, origin, mt, backend=None, **kwargs):
+def plot_polarities(filename, observed, predicted, stations, origin, mt, taup_model='ak135',backend=None, **kwargs):
     """ Plots first-motion polarities
 
     .. rubric :: Required arguments
@@ -118,13 +118,18 @@ def plot_polarities(filename, observed, predicted, stations, origin, mt, backend
     ``mt`` (`mtuq.MomentTensor`):
     Moment tensor object
 
+    .. rubric :: Optional arguments
+
+    ``taup_model`` (`str`):
+    Name of built-in ObsPy TauP model or path to custom ObsPy TauP model,
+    used for takeoff angle calculations. ak135 model used by default. 
+
     """
     if backend is None:
         backend = _plot_beachball_matplotlib
 
         polarity_data = np.vstack((observed, predicted))
-
-        backend(filename, mt, stations, origin, polarity_data=polarity_data, **kwargs)
+        backend(filename, mt, taup_model, stations, origin, polarity_data=polarity_data, **kwargs)
         return
     
     if exists_pygmt():
@@ -143,7 +148,7 @@ GMT_PROJECTION = '-Jm0/0/5c'
 
 
 def _plot_beachball_gmt(filename, mt, stations, origin,
-    taup_model='ak135', add_station_markers=True, add_station_labels=True,
+    taup_model, add_station_markers=True, add_station_labels=True,
     fill_color='gray', marker_color='black'):
 
 
@@ -265,7 +270,7 @@ PYGMT_SCALE     = '9.9c'
 
 
 def _plot_beachball_pygmt(filename, mt, stations, origin,
-    taup_model='ak135', add_station_labels=True, add_station_markers=True,
+    taup_model, add_station_labels=True, add_station_markers=True,
     fill_color='gray', marker_color='black'):
 
     import pygmt
@@ -457,8 +462,8 @@ def _polar2(stations, **kwargs):
     __polar2(stations, **kwargs)
 
 
-def _plot_beachball_matplotlib(filename, mt_arrays, stations=None, origin=None, lon_lats=None, 
-                               scale=None, fig=None, ax=None, taup_model='ak135', color='gray', 
+def _plot_beachball_matplotlib(filename, mt_arrays,taup_model, stations=None, origin=None,lon_lats=None, 
+                               scale=None, fig=None, ax=None, color='gray', 
                                lune_rotation=False, polarity_data=None, **kwargs):
     
     from scipy.interpolate import griddata

--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -148,7 +148,7 @@ GMT_PROJECTION = '-Jm0/0/5c'
 
 
 def _plot_beachball_gmt(filename, mt, stations, origin,
-    taup_model, add_station_markers=True, add_station_labels=True,
+    taup_model='ak135', add_station_markers=True, add_station_labels=True,
     fill_color='gray', marker_color='black'):
 
 
@@ -270,7 +270,7 @@ PYGMT_SCALE     = '9.9c'
 
 
 def _plot_beachball_pygmt(filename, mt, stations, origin,
-    taup_model, add_station_labels=True, add_station_markers=True,
+    taup_model='ak135', add_station_labels=True, add_station_markers=True,
     fill_color='gray', marker_color='black'):
 
     import pygmt
@@ -462,7 +462,7 @@ def _polar2(stations, **kwargs):
     __polar2(stations, **kwargs)
 
 
-def _plot_beachball_matplotlib(filename, mt_arrays,taup_model, stations=None, origin=None,lon_lats=None, 
+def _plot_beachball_matplotlib(filename, mt_arrays,taup_model='ak135', stations=None, origin=None,lon_lats=None, 
                                scale=None, fig=None, ax=None, color='gray', 
                                lune_rotation=False, polarity_data=None, **kwargs):
     


### PR DESCRIPTION
The subroutines [plot_beachball](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L35) and [plot_polarities](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L98) in their current form does not contain taup_model as a required parameter, or at least as an optional one with a default value. Therefore, if the user wants to  specify the velocity model to use for calculating the piercing points on the beachball, this parameter has to be passed as a keyword argument by the user. Otherwise,  the ak135 model will be used when these functions invoke [_plot_beachball_matplotlib](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L127), [_plot_beachball_pygmt](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L81), and [_plot_beachball_gmt](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L84). 


I think that this approach makes the MTUQ user prone to errors by having discrepancies in the polarity calculation - since this information is retrieved independently and in that case, the  velocity model is a required parameter prior calling [_takeoff_angle_taup](https://github.com/mtuqorg/mtuq/blob/70f0d55d402e244bdc415fd08ea8409430679414/mtuq/misfit/polarity.py#L274)-and the piercing points calculation when [_takeoff_angle_taup](https://github.com/mtuqorg/mtuq/blob/master/mtuq/graphics/beachball.py#L613) is called again for plotting the stations and the polarities in the beachball, but in this case the velocity model is a keyword argument.

For example, MTUQ in its current form, when running [Waveforms+Polarities.py](https://github.com/mtuqorg/mtuq/blob/master/examples/Waveforms%2BPolarities.py), as is, the result is:

![Screenshot 2025-04-04 at 11 50 01 PM](https://github.com/user-attachments/assets/8077b02c-ae05-4fa2-8ae2-f06d541f9aeb)

which is correct, since the model used is AK135. 

However, the same code after changing the model to PREM, but leaving plot_beachball and plot_polarities as is yields an inconsistency between the piercing points (calculated by default with ak135) and the predicted polarities (calculated with PREM):

![Screenshot 2025-04-05 at 12 09 14 AM](https://github.com/user-attachments/assets/f7d79144-8c3b-4ca2-8056-d293c354fb73)

However, if taup_model model is passed by the user as a keyword argument , the polarity calculation and the beachball plots are consistent:

![Screenshot 2025-04-05 at 12 20 07 AM](https://github.com/user-attachments/assets/d091e3ea-a080-4467-aec3-eec9c655e6cb)

I propose to define taup_model directly in the public subroutines plot_beachball and plot_polarities, rather than being a keyword argument. I think this may help the users not having discrepancies between the predicted polarities and the piercing points by using different models in both processes. In my case, it took me some time realizing that taup_model could be passed as a keyword argument into plot_polarities, since this is not explicity mentioned in the docstring unlike plot_beachball. In the way I am proposing the modifications, mantains AK135 as the default model if is not specified in   plot_beachball and plot_polarities, with the aim of not affecting the current examples, where this parameter is not passed to those subroutines. 

Sorry for the long explanation. If you consider, that this modification is unncessary, I understand if you want to keep the taup_model parameter  as a keyword argument in plot_beachball and plot_polarities. However, I would kindly ask, at least, to include this parameter in the docstring of plot_polarities for avoiding any confusion to current and future users. 

Thanks. 