### PR TITLE
New conda env config file, and update Github action build option.

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -11,7 +11,7 @@ jobs:
 
     # we find that CPU/memory limits are less often exceeded using this 
     # specific version of Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     #runs-on: ubuntu-latest
 

--- a/env_arm64.yaml
+++ b/env_arm64.yaml
@@ -4,7 +4,7 @@ channels:
 
 dependencies:
   - conda-build
-  - python=3.12.3
+  - python<=3.12.3
   - numpy 
   - scipy 
   - obspy 

--- a/env_default.yaml
+++ b/env_default.yaml
@@ -4,7 +4,7 @@ channels:
 
 dependencies:
   - conda-build
-  - python=3.12.3
+  - python<=3.12.3
   - numpy 
   - scipy 
   - obspy 


### PR DESCRIPTION
With the release of Python 3.13.3 (April 8, 2025), it seems that `Instaseis` is again causing issues at compilation, and prevent the installation of `MTUQ`. 

Forcing the Python version to be <= 3.12.3 seems to be a good solution for now. 

Looking at the details of the installation error within pip (bellow), I'd say there might be an issue with the Scipy wheel for python 3.13.3 (I have tested this behavior both on Linux and ARM-based MacOs).

I have also update the github action to use a different Ubuntu version, since the 20.04 is not supported by Github anymore.


```bash
Installing pip dependencies: / Ran pip subprocess with arguments:
['/Users/julienthurin/opt/anaconda3/envs/mtuq_00/bin/python', '-m', 'pip', 'install', '-U', '-r', '/Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt', '--exists-action=b']
Pip subprocess output:
Collecting git+https://github.com/rmodrak/instaseis.git (from -r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1))
  Cloning https://github.com/rmodrak/instaseis.git to /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-req-build-hd_6_uu1
  Resolved https://github.com/rmodrak/instaseis.git to commit 1b71b1f112f693dd7eb93e21fe82ada559e1954b
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Obtaining file:///Users/julienthurin/Documents/GitHub/mtuq (from -r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 3))
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting tables (from -r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 2))
  Using cached tables-3.10.2-cp313-cp313-macosx_10_13_x86_64.whl.metadata (2.0 kB)
Requirement already satisfied: h5py in /Users/julienthurin/opt/anaconda3/envs/mtuq_00/lib/python3.13/site-packages (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1)) (3.13.0)
Requirement already satisfied: numpy in /Users/julienthurin/opt/anaconda3/envs/mtuq_00/lib/python3.13/site-packages (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1)) (2.2.5)
Requirement already satisfied: obspy>=1.2.1 in /Users/julienthurin/opt/anaconda3/envs/mtuq_00/lib/python3.13/site-packages (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1)) (1.4.2)
Collecting tornado>=6.0.0 (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1))
  Using cached tornado-6.4.2-cp38-abi3-macosx_10_9_x86_64.whl.metadata (2.5 kB)
Requirement already satisfied: requests in /Users/julienthurin/opt/anaconda3/envs/mtuq_00/lib/python3.13/site-packages (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1)) (2.32.3)
Collecting geographiclib (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1))
  Using cached geographiclib-2.0-py3-none-any.whl.metadata (1.4 kB)
Requirement already satisfied: jsonschema>=2.4.0 in /Users/julienthurin/opt/anaconda3/envs/mtuq_00/lib/python3.13/site-packages (from instaseis==0.0.0.dev0+0.g1b71b1f112->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 1)) (4.23.0)
Collecting scipy<1.13.0 (from mtuq==0.2.0->-r /Users/julienthurin/Documents/GitHub/mtuq/condaenv.zmdmcc91.requirements.txt (line 3))
  Using cached scipy-1.12.0.tar.gz (56.8 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): still running...
  Preparing metadata (pyproject.toml): finished with status 'error'

Pip subprocess error:
  Running command git clone --filter=blob:none --quiet https://github.com/rmodrak/instaseis.git /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-req-build-hd_6_uu1
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      + meson setup /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08 /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08/.mesonpy-u5evuo53 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08/.mesonpy-u5evuo53/meson-python-native-file.ini
      The Meson build system
      Version: 1.8.0
      Source dir: /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08
      Build dir: /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08/.mesonpy-u5evuo53
      Build type: native build
      Project name: scipy
      Project version: 1.12.0
      C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 18.1.8 "clang version 18.1.8")
      C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 951.9
      C++ compiler for the host machine: c++ (clang 12.0.5 "Apple clang version 12.0.5 (clang-1205.0.22.9)")
      C++ linker for the host machine: c++ ld64 650.9
      Cython compiler for the host machine: cython (cython 3.0.12)
      Host machine cpu family: x86_64
      Host machine cpu: x86_64
      Program python found: YES (/Users/julienthurin/opt/anaconda3/envs/mtuq_00/bin/python)
      Found pkg-config: YES (/opt/homebrew/bin/pkg-config) 2.4.3
      Run-time dependency python found: YES 3.13
      Program cython found: YES (/private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-build-env-gxs8wuii/overlay/bin/cython)
      Compiler for C supports arguments -Wno-unused-but-set-variable: YES
      Compiler for C supports arguments -Wno-unused-function: YES
      Compiler for C supports arguments -Wno-conversion: YES
      Compiler for C supports arguments -Wno-misleading-indentation: YES
      Library m found: YES
      Fortran compiler for the host machine: /Users/julienthurin/opt/anaconda3/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 13.2.0 "GNU Fortran (GCC) 13.2.0")
      Fortran linker for the host machine: /Users/julienthurin/opt/anaconda3/bin/x86_64-apple-darwin13.4.0-gfortran ld64 609
      Compiler for Fortran supports arguments -Wno-conversion: YES
      Compiler for C supports link arguments -Wl,-ld_classic: YES
      Checking if "-Wl,--version-script" links: NO
      Program pythran found: YES (/private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-build-env-gxs8wuii/overlay/bin/pythran)
      Found CMake: /opt/homebrew/bin/cmake (3.26.3)
      WARNING: CMake Toolchain: Failed to determine CMake compilers state
      Run-time dependency xsimd found: NO (tried pkgconfig, framework and cmake)
      Run-time dependency threads found: YES
      Library npymath found: YES
      Library npyrandom found: YES
      pybind11-config found: YES (/private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-build-env-gxs8wuii/overlay/bin/pybind11-config) 2.11.2
      Run-time dependency pybind11 found: YES 2.11.2
      Run-time dependency scipy-openblas found: NO (tried pkgconfig)
      Run-time dependency openblas found: NO (tried pkgconfig, framework and cmake)
      Run-time dependency openblas found: NO (tried pkgconfig, framework and cmake)

      ../scipy/meson.build:169:9: ERROR: Dependency "OpenBLAS" not found, tried pkgconfig, framework and cmake

      A full log can be found at /private/var/folders/1p/htglmqvd0lx940g2r3200r800000gn/T/pip-install-5lykk0da/scipy_b8115ceab749401585dc2a3eeeb06b08/.mesonpy-u5evuo53/meson-logs/meson-log.txt
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

failed

CondaEnvException: Pip failed
```