### PR TITLE
Waveform plot update

### DIFF
--- a/mtuq/graphics/_matplotlib.py
+++ b/mtuq/graphics/_matplotlib.py
@@ -3,65 +3,95 @@ import matplotlib.pyplot as plt
 from mtuq.util.beachball import lambert_azimuthal_equal_area_projection
 
 
-def plot_force_matplotlib(filename, force_dict):
+def plot_force_matplotlib(filename=None, force_dict=None, ax=None, show=False):
     """ Plots force orientation for waveform figure header using matplotlib
 
     .. rubric :: Parameters
 
     ``filename`` (`str`)
-    Name of output image file
+    Name of output image file (optional if ax is provided)
 
     ``force_dict`` (`dict`):
     Dictionary containing force orientation parameters
 
+    ``ax`` (matplotlib.axes.Axes):
+    Optional. If provided, plot directly on this axes.
+
+    ``show`` (bool):
+    If True, call plt.show() at the end (only if ax is not provided)
     """
 
-    pixel_width = 1807
-    pixel_height = 1806
+    fig = None
+    close_fig = False
 
-    dpi = 300  # You can adjust this if needed
+    # Default sizes for file output
+    textsize = 40
+    markersize = 28
+    linewidth_major = 2
+    linewidth_minor = 1
 
-    fig_width_in = pixel_width / dpi
-    fig_height_in = pixel_height / dpi
+    if ax is None:
+        # Only use pixel/dpi logic when saving to file
+        pixel_width = 1807
+        pixel_height = 1806
+        dpi = 300  # You can adjust this if needed
+        fig_width_in = pixel_width / dpi
+        fig_height_in = pixel_height / dpi
+        fig, ax = plt.subplots(figsize=(fig_width_in, fig_height_in), dpi=dpi)
+        close_fig = True
+    else:
+        # For inset axes, scale down for better appearance
+        # Use axes size to scale font/marker sizes
+        bbox = ax.get_window_extent().transformed(ax.figure.dpi_scale_trans.inverted())
+        width_in, height_in = bbox.width, bbox.height
+        # Use a base scaling factor (tweak as needed)
+        scale = min(width_in, height_in)
+        textsize = max(8, int(10 * scale))
+        markersize = max(4, int(5 * scale))
+        linewidth_major = max(0.5, 0.7 * scale)
+        linewidth_minor = max(0.3, 0.4 * scale)
 
-    fig, ax = plt.subplots(figsize=(fig_width_in, fig_height_in), dpi=dpi)
     ax.set_xlim(-1.01, 1.01)
     ax.set_ylim(-1.01, 1.01)
     ax.axis('off')
     ax.set_aspect('equal')
 
     # Minor arcs
-    _plot_arc([-90, 90], [0, 0], ax, major=False)
-    _plot_arc([0, 0], [-90, 90], ax, major=False)
-    _plot_arc([-90/2, -90/2], [-90, -7.5], ax, major=False)
-    _plot_arc([-90/2, -90/2], [90, 7.5], ax, major=False)
-    _plot_arc([+90/2, +90/2], [-90, -7.5], ax, major=False)
-    _plot_arc([+90/2, +90/2], [90, 7.5], ax, major=False)
-    _plot_arc([-90, 90], [-30, -30], ax, major=False)
-    _plot_arc([-90, 90], [30, 30], ax, major=False)
-    _plot_arc([-90, 90], [-60, -60], ax, major=False)
-    _plot_arc([-90, 90], [60, 60], ax, major=False)
+    _plot_arc([-90, 90], [0, 0], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([0, 0], [-90, 90], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90/2, -90/2], [-90, -7.5], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90/2, -90/2], [90, 7.5], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([+90/2, +90/2], [-90, -7.5], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([+90/2, +90/2], [90, 7.5], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90, 90], [-30, -30], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90, 90], [30, 30], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90, 90], [-60, -60], ax, major=False, linewidth=linewidth_minor)
+    _plot_arc([-90, 90], [60, 60], ax, major=False, linewidth=linewidth_minor)
     # Major arcs (rim of the circle)
-    _plot_arc([-90, -90], [-90, 90], ax, major=True)
-    _plot_arc([90, 90], [-90, 90], ax, major=True)
+    _plot_arc([-90, -90], [-90, 90], ax, major=True, linewidth=linewidth_major)
+    _plot_arc([90, 90], [-90, 90], ax, major=True, linewidth=linewidth_major)
 
     # Projecting and plotting the text labels
     x_w, y_w = _lambert_azimuthal_equal_area(-90/2, 0)
     x_e, y_e = _lambert_azimuthal_equal_area(90/2, 0)
-    ax.text(x_w, y_w, 'W', fontsize=40, ha='center', va='center', color='black')
-    ax.text(x_e, y_e, 'E', fontsize=40, ha='center', va='center', color='black')
+    ax.text(x_w, y_w, 'W', fontsize=textsize, ha='center', va='center', color='black')
+    ax.text(x_e, y_e, 'E', fontsize=textsize, ha='center', va='center', color='black')
 
-    # Plot force orientation -- black diamong piercing point
+    # Plot force orientation -- black diamond piercing point
     lat = np.degrees(np.pi/2 - np.arccos(force_dict['h']))
     lon = _wrap(force_dict['phi'] + 90.)/2 # -- recalling 0 is east, we add 90 to shift from south (center) to east
 
     x, y = _lambert_azimuthal_equal_area(lon, lat)
-    ax.plot(x, y, 'D', c='k', markersize=28)
+    ax.plot(x, y, 'D', c='k', markersize=markersize)
 
-    plt.tight_layout()
-    plt.savefig(filename, dpi=dpi, bbox_inches='tight', pad_inches=0)
-    plt.close(fig)
-    
+    if close_fig:
+        plt.tight_layout()
+        if filename:
+            plt.savefig(filename, dpi=dpi, bbox_inches='tight', pad_inches=0)
+        if show:
+            plt.show()
+        plt.close(fig)
+
 def _wrap(angle_in_deg):
     """ Wraps angle to (-180, 180)
     """
@@ -101,13 +131,13 @@ def _lambert_azimuthal_equal_area(lon, lat):
     return x, y
 
 
-def _plot_arc(lons_extent, lats_extent, ax, npts=100, major=True):
+def _plot_arc(lons_extent, lats_extent, ax, npts=100, major=True, linewidth=1):
     # Generate the points along the arc
     lon_arc = np.linspace(lons_extent[0], lons_extent[1], npts)
     lat_arc = np.linspace(lats_extent[0], lats_extent[1], npts)
 
     x_arc, y_arc = _lambert_azimuthal_equal_area(lon_arc, lat_arc)
     if major:
-        ax.plot(x_arc, y_arc, 'k-', linewidth=2)
+        ax.plot(x_arc, y_arc, 'k-', linewidth=linewidth)
     else:
-        ax.plot(x_arc, y_arc, c='gray', linewidth=1)
+        ax.plot(x_arc, y_arc, c='gray', linewidth=linewidth)

--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -73,7 +73,7 @@ def plot_beachball(filename, mt, stations, origin, backend=None, **kwargs):
     if type(mt)!=MomentTensor:
         raise TypeError
 
-    if backend is None:
+    if backend is None or backend == _plot_beachball_matplotlib:
         backend = _plot_beachball_matplotlib
         backend(filename, mt, stations, origin, **kwargs)
         return

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -471,16 +471,23 @@ class ForceHeader(SourceHeader):
         xp = offset
         yp = 0.075*height
 
-        backend('tmp.png', self.force_dict)
-        img = pyplot.imread('tmp.png')
-
-        try:
-            # os.remove('tmp.png')
-            os.remove('tmp.ps')
-        except:
-            pass
-
-        ax.imshow(img, extent=(xp,xp+diameter,yp,yp+diameter))
+        if backend == plot_force_matplotlib:
+            # Use inset axes and plot directly as vector graphics
+            inset_ax = ax.inset_axes([xp, yp, diameter, diameter], transform=ax.transData)
+            inset_ax.set_xticks([])
+            inset_ax.set_yticks([])
+            inset_ax.set_frame_on(False)
+            plot_force_matplotlib(force_dict=self.force_dict, ax=inset_ax)
+            inset_ax.axis('off')
+        else:
+            backend('tmp.png', self.force_dict)
+            img = pyplot.imread('tmp.png')
+            try:
+                os.remove('tmp.png')
+                os.remove('tmp.ps')
+            except:
+                pass
+            ax.imshow(img, extent=(xp,xp+diameter,yp,yp+diameter))
 
 
 

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -96,7 +96,7 @@ class SourceHeader(Base):
     def parse_origin(self):
         depth_in_m = self.origin.depth_in_m
         depth_in_km = self.origin.depth_in_m/1000.
-        if depth_in_m > 0:
+        if depth_in_m >= 0:
             if depth_in_m < 1000.:
                 self.depth_str = '%.0f m' % depth_in_m
             elif depth_in_km <= 100.:

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -1,4 +1,3 @@
-
 #
 # graphics/header.py - figure headers and text
 #
@@ -97,12 +96,24 @@ class SourceHeader(Base):
     def parse_origin(self):
         depth_in_m = self.origin.depth_in_m
         depth_in_km = self.origin.depth_in_m/1000.
-        if depth_in_m < 1000.:
-            self.depth_str = '%.0f m' % depth_in_m
-        elif depth_in_km <= 100.:
-            self.depth_str = '%.1f km' % depth_in_km
+        if depth_in_m > 0:
+            if depth_in_m < 1000.:
+                self.depth_str = '%.0f m' % depth_in_m
+            elif depth_in_km <= 100.:
+                self.depth_str = '%.1f km' % depth_in_km
+            else:
+                self.depth_str = '%.0f km' % depth_in_km
+            self.depth_label = 'Depth'
         else:
-            self.depth_str = '%.0f km' % depth_in_km
+            height_in_m = abs(depth_in_m)
+            height_in_km = abs(depth_in_km)
+            if height_in_m < 1000.:
+                self.depth_str = '%.0f m' % height_in_m
+            elif height_in_km <= 100.:
+                self.depth_str = '%.1f km' % height_in_km
+            else:
+                self.depth_str = '%.0f km' % height_in_km
+            self.depth_label = 'Height'
 
 
     def parse_misfit(self):
@@ -301,8 +312,8 @@ class MomentTensorHeader(SourceHeader):
         px += 0.00
         py -= 0.35
 
-        line = '%s  %s  $M_w$ %.2f  Depth %s' % (
-            self.event_name, _lat_lon(self.origin), self.magnitude, self.depth_str)
+        line = '%s  %s  $M_w$ %.2f  %s %s' % (
+            self.event_name, _lat_lon(self.origin), self.magnitude, self.depth_label, self.depth_str)
         _write_bold(line, px, py, ax, fontsize=16.5)
 
 
@@ -418,8 +429,8 @@ class ForceHeader(SourceHeader):
         px += 0.00
         py -= 0.35
 
-        line = '%s  %s  $F$ %.2e N   Depth %s' % (
-            self.event_name, _lat_lon(self.origin), self.force_dict['F0'], self.depth_str)
+        line = '%s  %s  $F$ %.2e N   %s %s' % (
+            self.event_name, _lat_lon(self.origin), self.force_dict['F0'], self.depth_label, self.depth_str)
         _write_bold(line, px, py, ax, fontsize=16)
 
 

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -488,11 +488,11 @@ class ForceHeader(SourceHeader):
             return
 
         # image size
-        diameter = 0.75*height
+        diameter = 0.8*height
 
         # image placement
         xp = offset
-        yp = 0.075*height
+        yp = (height - diameter) / 2 - 0.1*diameter
 
         if backend == plot_force_matplotlib:
             # Use inset axes and plot directly as vector graphics


### PR DESCRIPTION
This pull request introduces several changes to the waveform plotting module. The primary goal was to allow changing the label for Depth to Height, when source is above ground. 

I took this opportunity to also replace the clunky image generation that was used to add beachball and point force plots within the figure, so we can now generate fully vector based graphic plots (the images are no longer written as temporary images and displayed, and are instead directly plotted with the matplotlib backing in the axes of the header).

I will wait for @ammcpherson input to check that the Depth → Height switch is consistent with the workflow for airborne point force sources inversion using SPECFEM3D Green's functions, before proceeding with a merge.