### PR TITLE
Partial fix for Cython extensions

### DIFF
--- a/docs/install/issues.rst
+++ b/docs/install/issues.rst
@@ -3,10 +3,32 @@ Installation notes
 ==================
 
 
-Installation on Apple Silicon Macs
-----------------------------------
+A common cause of installation errors
+--------------------------------------
 
-MTUQ installation on Apple M1, M2 and M3 Macs is now possible using the default installation procedure.  A modified conda environment file is no longer necessary.
+On Unix-like systems, a non-writeable `/tmp` directory can cause the installation to fail in with unexpected or difficult-to-diagnose error messages.
+
+A useful troubleshooting step is to set the ``TMPDIR`` environment variable to a directory that exists and is writeable.
+
+
+Installation on Unix systems
+-----------------------------
+
+MTUQ installation is supported on Unix-like systems.
+
+
+Installation on MacOS systems
+-----------------------------
+
+MTUQ installation is supported on MacOS systems.
+
+MTUQ installation on Apple Silicon Macs is now possible using the default installation procedure.  A modified conda environment file is no longer necessary.
+
+
+Installation on Windows
+-----------------------
+
+MTUQ installation is not currently supported on Windows, however, we invite users to test it and contribute portability fixes.
 
 
 Cython extension modules
@@ -51,17 +73,6 @@ Alternatively, users can bypass Cython compilation errors by adding `optional=Tr
         )
 
 With this change, Cython errors will be ignored at install-time and MTUQ may fall back to slow pure Python functions at runtime.
-
-
-
-Instaseis installation
-----------------------
-
-MTUQ uses Instaseis to generate synthetic seismograms.
-
-Because Instaseis does not always install successfully under conda-forge, we implement a workaround using a modified Instaseis repository hosted on GitHub.
-
-Instaseis uses Fortran extensions for speedup, for which we install `fortran-compiler` the conda-forge package.
 
 
 

--- a/mtuq/misfit/waveform/__init__.py
+++ b/mtuq/misfit/waveform/__init__.py
@@ -121,7 +121,7 @@ class WaveformMisfit(object):
         time_shift_groups=['ZRT'],
         time_shift_min=0.,
         time_shift_max=0.,
-        optimization_level=2,
+        optimization_level=1,
         ):
         """ Function handle constructor
         """

--- a/mtuq/util/syngine.py
+++ b/mtuq/util/syngine.py
@@ -212,6 +212,6 @@ def _check(path):
             assert os.access(path, os.W_OK)
         except:
             path = abspath('./syngine/cache')
-            os.makedirs(path, exists_ok=True)
+            os.makedirs(path, exist_ok=True)
     return path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython>=0.29", "numpy"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "numpy<2"]

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,8 @@ setup(
             'mtuq.misfit.waveform.c_ext_L2', ['mtuq/misfit/waveform/c_ext_L2.c'],
             include_dirs=[numpy.get_include()],
             extra_compile_args=get_compile_args(),
+            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+            optional=True,
         )
     ],
 )


### PR DESCRIPTION
Recent changes to NumPy Cython API break MTUQ's Cython-accelerated misfit evaluation.  Even when they compile successfully, the Cython extensions may give bad results.  The PR turns off the Cython extensions for now. 